### PR TITLE
Added check for current version of node to launch script

### DIFF
--- a/bin/mobile-center.js
+++ b/bin/mobile-center.js
@@ -1,13 +1,47 @@
 #!/usr/bin/env node
 
-const path = require('path');
-const commandLine = require('../dist/util/commandline');
+// Verify user has minimum required version of node installed
+var minMajorVersion = 6;
+var minMinorVersion = 3;
 
-const runner = commandLine.runner(path.join(__dirname, '..', 'dist', 'commands'));
-runner(process.argv.slice(2))
-  .then((result) => {
-    if (commandLine.failed(result)) {
-      console.log(`Command failed, ${result.errorMessage}`);
-      process.exit(result.errorCode);
-    }
-  });
+function getCurrentVersion() {
+  var matches = process.version.match(/v?(\d+)\.(\d+)\.(\d+)/);
+  return [+matches[1], +matches[2]];
+}
+
+function ensureNodeVersion() {
+  var currentVersion = getCurrentVersion();
+  var major = currentVersion[0];
+  var minor = currentVersion[1];
+  if (major > minMajorVersion) {
+    return true;
+  }
+  if (major == minMajorVersion && minor >= minMinorVersion) {
+    return true;
+  }
+
+  console.log(`mobile-center command requires at least node version ${minMajorVersion}.${minMinorVersion}.0.`);
+  console.log(`You are currently running version ${process.version}.`);
+  console.log(`Please upgrade your version of node.js to at least ${minMajorVersion}.${minMinorVersion}.0`);
+  return false;
+}
+
+function runCli() {
+  var path = require('path');
+  var commandLine = require('../dist/util/commandline');
+
+  var runner = commandLine.runner(path.join(__dirname, '..', 'dist', 'commands'));
+  runner(process.argv.slice(2))
+    .then((result) => {
+      if (commandLine.failed(result)) {
+        console.log(`Command failed, ${result.errorMessage}`);
+        process.exit(result.errorCode);
+      }
+    });
+}
+
+if (ensureNodeVersion()) {
+  runCli();
+} else {
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-center-cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Command line tool for Microsoft Mobile Center",
   "keywords": [
     "microsoft",
@@ -10,7 +10,7 @@
   ],
   "homepage": "https://github.com/Microsoft/MobileCenter-cli#readme",
   "engine": {
-    "node": ">= 6.3.0"
+    "node": ">=6.3.0"
   },
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Had several weird error reports from customers that were caused by insufficient node versions. This gives an explicit error and fails to run if they don't meet minimum version requirements.
